### PR TITLE
Add warning before reloading

### DIFF
--- a/www/main.js
+++ b/www/main.js
@@ -9,6 +9,10 @@ function initialize() {
 
     windowWidth = $("#windowCanvas").width();
     windowHeight = $("#windowCanvas").height();
+    
+    window.onbeforeunload = function() {
+        return true;
+    };
 
     autonCreatorInit();
     loop();


### PR DESCRIPTION
Fixes #42. Cannot show a custom message in an alert box before unload though, as browsers explicitly block that according to [MDN](https://developer.mozilla.org/en-US/docs/web/api/window/beforeunload_event).

Commit tested on Firefox 99 and Chrome 99.